### PR TITLE
Adding the wp-to-txp repo

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -27,6 +27,7 @@ h2. Contents
 ** "Back-end":#back-end
 ** "Front-end":#front-end
 * "Resources":#resources
+** "Migration":#migration
 ** "Official resources":#resources-official
 ** "Web development software integration":#software-integration
 * "Community":#community
@@ -141,6 +142,10 @@ h3(#front-end). Front-end
 h2(#resources). Resources
 
 Various resources, such as books, websites and articles, for improving your Textpattern skills and knowledge.
+
+h3(#migration). Migration
+
+* "WP to Txp":https://github.com/NicolasGraph/wp-to-txp - WordPress developer helpful references.
 
 h3(#resources-official). Official resources
 


### PR DESCRIPTION
Here it is !
Not sure about the introduced header ; what do you think?
Also, I kept the alphabetical order, but maybe the "Official resources" should stick to the top?